### PR TITLE
	Add plot-file-size python script

### DIFF
--- a/plotfilesz.py
+++ b/plotfilesz.py
@@ -20,12 +20,12 @@ def filename_filter(f):
   invalidext=('.srt','.nfo','.sub','txt')
   return f.endswith(validext) and (not f.endswith(invalidext))
 
-
 def filesize_plot(rootpath):
 
   l=[]
   for root, dirs, files in os.walk(rootpath):
-    l.extend([os.path.getsize(root+"/"+f)/(1024.0*1024.0) for f in files if filename_filter(f)])
+    l.extend(map(lambda f: os.path.getsize(os.path.join(root,f))/(1024.0*1024.0), filter(filename_filter, files)))
+
   print len(l), "files. Min size =", min(l), "Max size=", max(l)
 
   density = gaussian_kde(l)

--- a/plotfilesz.py
+++ b/plotfilesz.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+
+'''
+ Plots a PDF of all the file sizes within a directory by recursively
+ walking the directory. This code demostrates the use of simple probability
+ functions and plotting in python.
+
+ For beter plotting directories containing movies or songs, it ignores
+ some types of files with extensions specified in the invalidext set.
+'''
+
+import os
+from sys import argv
+from pylab import *
+import matplotlib.pyplot as plt
+from scipy.stats import gaussian_kde
+
+def filename_filter(f):
+  validext=('')
+  invalidext=('.srt','.nfo','.sub','txt')
+  return True
+  #return f.endswith(validext) and (not f.endswith(invalidext))
+
+
+def filesize_plot(rootpath):
+
+  l=[]
+  #l2=[]
+  for root, dirs, files in os.walk(rootpath):
+    #l2.extend([(f, os.path.getsize(root+"/"+f)/(1024.0*1024.0)) for f in files if filename_filter(f)])
+    l.extend([os.path.getsize(root+"/"+f)/(1024.0*1024.0) for f in files if filename_filter(f)])
+  
+  #for a,b in l2:
+  #  print b,a
+
+  density = gaussian_kde(l)
+
+  print len(l), min(l), max(l)
+  # set the covariance_factor, lower means more detail
+  density.covariance_factor = lambda : .25
+  density._compute_covariance()
+
+  xs = np.linspace(min(l), max(l), 2000)
+  plt.xlabel('File size (MB)')
+  plt.ylabel('density')
+  plt.title('Probability density of files in ' + rootpath)
+  plt.grid(True)
+  plt.plot(xs,density(xs))
+  #l.sort()  
+  #plt.hist(l, bins=2000)
+  plt.show()
+
+filesize_plot(argv[1])
+

--- a/plotfilesz.py
+++ b/plotfilesz.py
@@ -18,24 +18,18 @@ from scipy.stats import gaussian_kde
 def filename_filter(f):
   validext=('')
   invalidext=('.srt','.nfo','.sub','txt')
-  return True
-  #return f.endswith(validext) and (not f.endswith(invalidext))
+  return f.endswith(validext) and (not f.endswith(invalidext))
 
 
 def filesize_plot(rootpath):
 
   l=[]
-  #l2=[]
   for root, dirs, files in os.walk(rootpath):
-    #l2.extend([(f, os.path.getsize(root+"/"+f)/(1024.0*1024.0)) for f in files if filename_filter(f)])
     l.extend([os.path.getsize(root+"/"+f)/(1024.0*1024.0) for f in files if filename_filter(f)])
-  
-  #for a,b in l2:
-  #  print b,a
+  print len(l), "files. Min size =", min(l), "Max size=", max(l)
 
   density = gaussian_kde(l)
 
-  print len(l), min(l), max(l)
   # set the covariance_factor, lower means more detail
   density.covariance_factor = lambda : .25
   density._compute_covariance()
@@ -46,6 +40,8 @@ def filesize_plot(rootpath):
   plt.title('Probability density of files in ' + rootpath)
   plt.grid(True)
   plt.plot(xs,density(xs))
+  
+  # Uncomment to print the histogram
   #l.sort()  
   #plt.hist(l, bins=2000)
   plt.show()

--- a/plotfilesz.py
+++ b/plotfilesz.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 
-'''
+"""
  Plots a PDF of all the file sizes within a directory by recursively
- walking the directory. This code demostrates the use of simple probability
+ walking the directory. This code demonstrates the use of simple probability
  functions and plotting in python.
 
- For beter plotting directories containing movies or songs, it ignores
+ For better plotting directories containing movies or songs, it ignores
  some types of files with extensions specified in the invalidext set.
-'''
+"""
 
 import os
 from sys import argv
@@ -15,36 +15,39 @@ from pylab import *
 import matplotlib.pyplot as plt
 from scipy.stats import gaussian_kde
 
+
 def filename_filter(f):
-  validext=('')
-  invalidext=('.srt','.nfo','.sub','txt')
-  return f.endswith(validext) and (not f.endswith(invalidext))
+    validext = ''
+    invalidext = ('.srt', '.nfo', '.sub', 'txt')
+    return f.endswith(validext) and (not f.endswith(invalidext))
 
-def filesize_plot(rootpath):
 
-  l=[]
-  for root, dirs, files in os.walk(rootpath):
-    l.extend(map(lambda f: os.path.getsize(os.path.join(root,f))/(1024.0*1024.0), filter(filename_filter, files)))
+def plot_file_size(rootpath):
+    l = []
+    for root, dirs, files in os.walk(rootpath):
+        l.extend(
+            map(lambda f: os.path.getsize(os.path.join(root, f)) / (1024.0 * 1024.0), filter(filename_filter, files)))
 
-  print len(l), "files. Min size =", min(l), "Max size=", max(l)
+    print len(l), "files. Min size =", min(l), "Max size=", max(l)
 
-  density = gaussian_kde(l)
+    density = gaussian_kde(l)
 
-  # set the covariance_factor, lower means more detail
-  density.covariance_factor = lambda : .25
-  density._compute_covariance()
+    # set the covariance_factor, lower means more detail
+    density.covariance_factor = lambda: .25
+    density._compute_covariance()
 
-  xs = np.linspace(min(l), max(l), 2000)
-  plt.xlabel('File size (MB)')
-  plt.ylabel('density')
-  plt.title('Probability density of files in ' + rootpath)
-  plt.grid(True)
-  plt.plot(xs,density(xs))
-  
-  # Uncomment to print the histogram
-  #l.sort()  
-  #plt.hist(l, bins=2000)
-  plt.show()
+    xs = np.linspace(min(l), max(l), 2000)
+    plt.xlabel('File size (MB)')
+    plt.ylabel('density')
+    plt.title('Probability density of files in ' + rootpath)
+    plt.grid(True)
+    plt.plot(xs, density(xs))
 
-filesize_plot(argv[1])
+    # Uncomment to print the histogram
+    # l.sort()  
+    #plt.hist(l, bins=2000)
+    plt.show()
+
+
+plot_file_size(argv[1])
 


### PR DESCRIPTION
Plots a PDF of all the file sizes within a directory by recursively
walking the directory. This code demostrates the use of simple
probability functions and plotting in python.

For beter plotting directories containing movies or songs, it ignores
some types of files with extensions specified in the invalidext set.